### PR TITLE
Add support for Mac Pro Chrome

### DIFF
--- a/src/enums.ts
+++ b/src/enums.ts
@@ -95,6 +95,7 @@ export function colorDepth(value: number) {
       result += "SIXTEEN";
       break;
     case 24:
+    case 30:
       result += "TWENTY_FOUR";
       break;
     case 32:


### PR DESCRIPTION
# Summary

Chrome on Macbook Pros report a default colorDepth of 30 as detailed here: https://bugs.chromium.org/p/chromium/issues/detail?id=1095999

This causes an error to be thrown in 3DSv2 for an unsupported color depth.  Following the technical bulletin the colorDepth should conform to the following: "3ds servers and network directory servers to step down to the closest value thats part of the spec"